### PR TITLE
Hotfix/2731 vnet outputs

### DIFF
--- a/examples/main/outputs_example.tf
+++ b/examples/main/outputs_example.tf
@@ -4,14 +4,30 @@ output "resource_group_name" {
   sensitive   = false
 }
 
-output "resource_name" {
+output "vnet_name" {
   description = "The resource name."
   value       = module.example.vnet_name
   sensitive   = false
 }
 
-output "resource_id" {
+output "vnet_resource_id" {
   description = "The resource id."
   value       = module.example.vnet_resource_id
   sensitive   = false
+}
+
+
+output "subnets" {
+  description = "Detailed information about each subnet."
+  value       = module.example.subnets
+}
+
+output "nsg_ids" {
+  description = "The IDs of the network security groups"
+  value       = module.example.nsg_ids
+}
+
+output "route_table_ids" {
+  description = "The IDs of the route tables"
+  value       = module.example.route_table_ids
 }

--- a/outputs_vnet.tf
+++ b/outputs_vnet.tf
@@ -5,7 +5,7 @@ output "vnet_resource_id" {
 
 output "resource_group_name" {
   description = "The name of the resource group where the virtual network is created."
-  value       = module.avm_res_network_virtualnetwork.resource_group_name
+  value       = var.resource_group_name
 }
 
 output "vnet_name" {
@@ -19,15 +19,17 @@ output "subnets" {
     for subnet in module.avm_res_network_virtualnetwork.subnets : subnet.name => {
       resource_id                                   = subnet.resource_id
       name                                          = subnet.name
-      address_prefix                                = subnet.address_prefix
-      default_gateway                               = cidrhost(subnet.address_prefix, 1)
-      network_security_group_id                     = subnet.network_security_group_id
-      route_table_id                                = subnet.route_table_id
-      service_endpoints                             = subnet.service_endpoints
-      delegation                                    = try(subnet.delegation, null)
-      private_endpoint_network_policies_enabled     = try(subnet.private_endpoint_network_policies_enabled, null)
-      private_link_service_network_policies_enabled = try(subnet.private_link_service_network_policies_enabled, null)
-      nat_gateway_id                                = try(subnet.nat_gateway_id, null)
+      address_prefix                                = try(subnet.resource.body.properties.addressPrefixes[0], null)
+      address_prefixes                              = try(subnet.resource.body.properties.addressPrefixes, [])
+      default_gateway                               = try(cidrhost(subnet.resource.body.properties.addressPrefixes[0], 1), null)
+      network_security_group_id                     = try(subnet.resource.body.properties.networkSecurityGroup.id, null)
+      route_table_id                                = try(subnet.resource.body.properties.routeTable.id, null)
+      delegation                                    = try(subnet.resource.body.properties.delegations, null)
+      delegated_service_name                        = try(subnet.resource.body.properties.delegations[0].properties.serviceName, null)
+      private_endpoint_network_policies_enabled     = try(subnet.resource.body.properties.privateEndpointNetworkPolicies, null)
+      private_link_service_network_policies_enabled = try(subnet.resource.body.properties.privateLinkServiceNetworkPolicies, null)
+      service_endpoints                             = try([for s in subnet.resource.body.properties.serviceEndpoints : s.service], [])
+      nat_gateway_id                                = try(subnet.resource.body.properties.natGateway.id, null)
     }
   }
 }


### PR DESCRIPTION
# Pull Request Template

## 📲 What

This fix corrects the outputs implamented within 2731 which cause the onward TF to break.

Corrected the output resources group, which was not output by the avm module 
Correcting the detail breack down of the subnet block

## 🤔 Why

This fix corrects the outputs implamented within 2731 which cause the onward TF to break.

## 🛠 How


## 👀 Evidence

![image](https://github.com/user-attachments/assets/64019e62-f60c-47fc-b512-076c5aeeb8c8)

Outputs:
```json
nsg_ids = {
  "subnet1" = "/subscriptions/zzz/resourceGroups/rg-ens-uks-default-evm-393/providers/Microsoft.Network/networkSecurityGroups/nsg-vnet-ens-uks-default-evm-393-subnet-test-inbound"
  "subnet2" = "/subscriptions/zzz/resourceGroups/rg-ens-uks-default-evm-393/providers/Microsoft.Network/networkSecurityGroups/nsg-vnet-ens-uks-default-evm-393-subnet-test-outbound"
  "subnet3" = "/subscriptions/zzz/resourceGroups/rg-ens-uks-default-evm-393/providers/Microsoft.Network/networkSecurityGroups/nsg-vnet-ens-uks-default-evm-393-pvt-subnet"
}
resource_group_name = "rg-ens-uks-default-evm-393"
route_table_ids = {
  "AzureFirewallSubnet" = "/subscriptions/zzz/resourceGroups/rg-ens-uks-default-evm-393/providers/Microsoft.Network/routeTables/rt-vnet-ens-uks-default-evm-393-AzureFirewallSubnet"
  "GatewaySubnet" = "/subscriptions/zzz/resourceGroups/rg-ens-uks-default-evm-393/providers/Microsoft.Network/routeTables/rt-vnet-ens-uks-default-evm-393-GatewaySubnet"
  "subnet1" = "/subscriptions/zzz/resourceGroups/rg-ens-uks-default-evm-393/providers/Microsoft.Network/routeTables/rt-vnet-ens-uks-default-evm-393-subnet-test-inbound"
  "subnet2" = "/subscriptions/zzz/resourceGroups/rg-ens-uks-default-evm-393/providers/Microsoft.Network/routeTables/rt-vnet-ens-uks-default-evm-393-subnet-test-outbound"
  "subnet3" = "/subscriptions/zzz/resourceGroups/rg-ens-uks-default-evm-393/providers/Microsoft.Network/routeTables/rt-vnet-ens-uks-default-evm-393-pvt-subnet"
}
subnets = {
  "AzureFirewallSubnet" = {
    "address_prefix" = "10.0.5.0/26"
    "address_prefixes" = tolist([
      "10.0.5.0/26",
    ])
    "default_gateway" = "10.0.5.1"
    "delegated_service_name" = null
    "delegation" = []
    "name" = "AzureFirewallSubnet"
    "nat_gateway_id" = null
    "network_security_group_id" = null
    "private_endpoint_network_policies_enabled" = "Disabled"
    "private_link_service_network_policies_enabled" = "Disabled"
    "resource_id" = "/subscriptions/zzz/resourceGroups/rg-ens-uks-default-evm-393/providers/Microsoft.Network/virtualNetworks/vnet-ens-uks-default-evm-393/subnets/AzureFirewallSubnet"
    "route_table_id" = "/subscriptions/zzz/resourceGroups/rg-ens-uks-default-evm-393/providers/Microsoft.Network/routeTables/rt-vnet-ens-uks-default-evm-393-AzureFirewallSubnet"
    "service_endpoints" = []
    "tags" = tomap({})
  }
  "GatewaySubnet" = {
    "address_prefix" = "10.0.4.0/27"
    "address_prefixes" = tolist([
      "10.0.4.0/27",
    ])
    "default_gateway" = "10.0.4.1"
    "delegated_service_name" = null
    "delegation" = []
    "name" = "GatewaySubnet"
    "nat_gateway_id" = null
    "network_security_group_id" = null
    "private_endpoint_network_policies_enabled" = "Disabled"
    "private_link_service_network_policies_enabled" = "Disabled"
    "resource_id" = "/subscriptions/zzz/resourceGroups/rg-ens-uks-default-evm-393/providers/Microsoft.Network/virtualNetworks/vnet-ens-uks-default-evm-393/subnets/GatewaySubnet"
    "route_table_id" = "/subscriptions/zzz/resourceGroups/rg-ens-uks-default-evm-393/providers/Microsoft.Network/routeTables/rt-vnet-ens-uks-default-evm-393-GatewaySubnet"
    "service_endpoints" = []
    "tags" = tomap({})
  }
  "pvt-subnet" = {
    "address_prefix" = "10.0.3.0/24"
    "address_prefixes" = tolist([
      "10.0.3.0/24",
    ])
    "default_gateway" = "10.0.3.1"
    "delegated_service_name" = null
    "delegation" = []
    "name" = "pvt-subnet"
    "nat_gateway_id" = null
    "network_security_group_id" = "/subscriptions/zzz/resourceGroups/rg-ens-uks-default-evm-393/providers/Microsoft.Network/networkSecurityGroups/nsg-vnet-ens-uks-default-evm-393-pvt-subnet"
    "private_endpoint_network_policies_enabled" = "Disabled"
    "private_link_service_network_policies_enabled" = "Enabled"
    "resource_id" = "/subscriptions/zzz/resourceGroups/rg-ens-uks-default-evm-393/providers/Microsoft.Network/virtualNetworks/vnet-ens-uks-default-evm-393/subnets/pvt-subnet"
    "route_table_id" = "/subscriptions/zzz/resourceGroups/rg-ens-uks-default-evm-393/providers/Microsoft.Network/routeTables/rt-vnet-ens-uks-default-evm-393-pvt-subnet"
    "service_endpoints" = [
      "Microsoft.KeyVault",
      "Microsoft.Storage",
    ]
    "tags" = tomap({})
  }
  "subnet-test-inbound" = {
    "address_prefix" = "10.0.1.0/24"
    "address_prefixes" = tolist([
      "10.0.1.0/24",
    ])
    "default_gateway" = "10.0.1.1"
    "delegated_service_name" = null
    "delegation" = []
    "name" = "subnet-test-inbound"
    "nat_gateway_id" = null
    "network_security_group_id" = "/subscriptions/zzz/resourceGroups/rg-ens-uks-default-evm-393/providers/Microsoft.Network/networkSecurityGroups/nsg-vnet-ens-uks-default-evm-393-subnet-test-inbound"
    "private_endpoint_network_policies_enabled" = "Disabled"
    "private_link_service_network_policies_enabled" = "Enabled"
    "resource_id" = "/subscriptions/zzz/resourceGroups/rg-ens-uks-default-evm-393/providers/Microsoft.Network/virtualNetworks/vnet-ens-uks-default-evm-393/subnets/subnet-test-inbound"
    "route_table_id" = "/subscriptions/zzz/resourceGroups/rg-ens-uks-default-evm-393/providers/Microsoft.Network/routeTables/rt-vnet-ens-uks-default-evm-393-subnet-test-inbound"
    "service_endpoints" = [
      "Microsoft.KeyVault",
      "Microsoft.Storage",
    ]
    "tags" = tomap({})
  }
  "subnet-test-outbound" = {
    "address_prefix" = "10.0.2.0/24"
    "address_prefixes" = tolist([
      "10.0.2.0/24",
    ])
    "default_gateway" = "10.0.2.1"
    "delegated_service_name" = "Microsoft.Web/serverFarms"
    "delegation" = tolist([
      {
        "name" = "Microsoft.Web.serverFarms"
        "properties" = {
          "serviceName" = "Microsoft.Web/serverFarms"
        }
      },
    ])
    "name" = "subnet-test-outbound"
    "nat_gateway_id" = null
    "network_security_group_id" = "/subscriptions/zzz/resourceGroups/rg-ens-uks-default-evm-393/providers/Microsoft.Network/networkSecurityGroups/nsg-vnet-ens-uks-default-evm-393-subnet-test-outbound"
    "private_endpoint_network_policies_enabled" = "Disabled"
    "network_security_group_id" = "/subscriptions/zzz/resourceGroups/rg-ens-uks-default-evm-393/providers/Microsoft.Network/networkSecurityGroups/nsg-vnet-ens-uks-default-evm-393-subnet-test-outbound"
    "private_endpoint_network_policies_enabled" = "Disabled"
    "private_link_service_network_policies_enabled" = "Enabled"
    "resource_id" = "/subscriptions/zzz/resourceGroups/rg-ens-uks-default-evm-393/providers/Microsoft.Network/virtualNetworks/vnet-ens-uks-default-evm-393/subnets/subnet-test-outbound"
    "route_table_id" = "/subscriptions/zzz/resourceGroups/rg-ens-uks-default-evm-393/providers/Microsoft.Network/routeTables/rt-vnet-ens-uks-default-evm-393-subnet-test-outbound"
    "service_endpoints" = [
      "Microsoft.KeyVault",
      "Microsoft.Storage",
    ]
    "tags" = tomap({})
  }
}
vnet_name = "vnet-ens-uks-default-evm-393"
vnet_resource_id = "/subscriptions/zzz/resourceGroups/rg-ens-uks-default-evm-393/providers/Microsoft.Network/virtualNetworks/vnet-ens-uks-default-evm-393"
```

## 🕵️ How to test

Run the example TF